### PR TITLE
Remove x264

### DIFF
--- a/com.github.vkohaupt.vokoscreenNG.yml
+++ b/com.github.vkohaupt.vokoscreenNG.yml
@@ -17,28 +17,6 @@ finish-args:
   - --talk-name=org.kde.StatusNotifierWatcher
 
 modules:
-  - name: x264
-    config-opts:
-      - --enable-shared
-      - --disable-cli
-      - --system-libx264
-      - --enable-pic
-      - --enable-lto
-    sources:
-      - type: git
-        url: https://code.videolan.org/videolan/x264.git
-        branch: stable
-        commit: baee400fa9ced6f5481a728138fed6e867b0ff7f
-
-  - name: gstreamer-plugins-ugly
-    buildsystem: meson
-    config-opts:
-      - -D=x264=enabled
-    sources:
-      - type: archive
-        url: https://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-1.18.5.tar.xz
-        sha256: df32803e98f8a9979373fa2ca7e05e62f977b1097576d3a80619d9f5c69f66d9
-
   - name: vokoscreenNG
     buildsystem: qmake
     subdir: src


### PR DESCRIPTION
For better understanding in Germany.

Aus Lizenzrechtlichen Gründen wurde das einbinden von x264 im vokoscreenNG Quellcode für Flatpak unterbunden. Das heißt, dass hier in der .yml Datei das einbinden von x264 nicht mehr benötigt wird.